### PR TITLE
Drop `gcc` as a dependency

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,6 +18,9 @@ if [ "$(uname)" == "Darwin" ]; then
   export LDFLAGS="${LDFLAGS} -stdlib=libc++ -std=c++11"
   export LINKFLAGS="${LDFLAGS}"
   export MACOSX_DEPLOYMENT_TARGET=10.7
+elif [ "$(uname)" == "Linux" ]; then
+  # Stop Boost from using libquadmath.
+  CXXFLAGS="${CXXFLAGS} -DBOOST_MATH_DISABLE_FLOAT128"
 fi
 
 export CXXFLAGS="${CXXFLAGS} -fPIC"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,6 @@ requirements:
     - autoconf
     - automake
     - cmake
-    - gcc
     - libtool
     - openssl
     - bison
@@ -26,7 +25,6 @@ requirements:
     - zlib 1.2*
 
   run:
-    - libgcc
     - openssl
     - zlib 1.2*
 


### PR DESCRIPTION
This drops `gcc` as a dependency. The first commit here should fail. The second one that will be pushed should fix it. The point here is to resolve the `quadmath.h` missing error and still use the standard toolchain.

What did we do here? Disable Boost float128 bit support to let this build smoothly. Inspired by this ticket ( https://svn.boost.org/trac/boost/ticket/9240 ), which added the feature Thus we now don't need `libquadmath`. We demonstrate this works by first removing the `gcc` dependency and then adding the flag for Boost.
