### PR TITLE
Correct header-only boost dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,10 +19,7 @@ source:
   {% endif %}
 
 build:
-  number: 4
-  ignore_run_exports:
-    # Only uses headers, no libs.
-    - boost-cpp
+  number: 5
   run_exports:
     - {{ pin_subpackage("thrift-cpp", max_pin="x.x") }}
 
@@ -45,9 +42,6 @@ requirements:
     - openssl
     - zlib
   run:
-  run_constrained:
-    # Ensure only compatible boost versions are installed alongside.
-    - {{ pin_compatible('boost-cpp', max_pin='x.x') }}
 
 test:
   commands:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
