### PR TITLE
Fix libthrift pinning in run export

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ outputs:
     script: install.bat  # [not unix]
     build:
       run_exports:
-        - {{ pin_subpackage("libthrift", max_pin="x.x") }}
+        - {{ pin_subpackage("libthrift", max_pin="x.x.x") }}
     requirements:
       build:
         - {{ compiler("c") }}
@@ -83,7 +83,7 @@ outputs:
     script: install.bat  # [not unix]
     build:
       run_exports:
-        - {{ pin_subpackage("libthrift", max_pin="x.x") }}
+        - {{ pin_subpackage("libthrift", max_pin="x.x.x") }}
     requirements:
       build:
         - {{ compiler("c") }}
@@ -112,7 +112,7 @@ outputs:
   - name: thrift-cpp
     build:
       run_exports:
-        - {{ pin_subpackage("libthrift", max_pin="x.x") }}
+        - {{ pin_subpackage("libthrift", max_pin="x.x.x") }}
     requirements:
       host:
         - {{ pin_subpackage("libthrift", exact=true) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
   {% endif %}
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("libthrift", max_pin="x.x.x") }}
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
